### PR TITLE
[WIP] Example end-to-end RAG MVP

### DIFF
--- a/lm_eval/tasks/unitxt/unitxt
+++ b/lm_eval/tasks/unitxt/unitxt
@@ -1,1 +1,1 @@
-class: !function task.Unitxt
+class: !function task.UnitxtFactory

--- a/lm_eval/tasks/unitxt/unitxt_rag
+++ b/lm_eval/tasks/unitxt/unitxt_rag
@@ -1,0 +1,1 @@
+class: !function task.UnitxtRAG

--- a/lm_eval/tasks/unitxt/unitxt_rag
+++ b/lm_eval/tasks/unitxt/unitxt_rag
@@ -1,1 +1,0 @@
-class: !function task.UnitxtRAG

--- a/lm_eval/tasks/unitxt/utils.py
+++ b/lm_eval/tasks/unitxt/utils.py
@@ -7,7 +7,7 @@ def process_docs(
     dataset: datasets.Dataset, contexts: tuple[list[str]]
 ) -> datasets.Dataset:
     def _process_doc(doc, ctx):
-        out_doc = {**doc, "source": ctx[0], "source_ids": ctx[1]}
+        out_doc = {**doc, "contexts": ctx[0], "context_ids": ctx[1]}
         return out_doc
 
     return list(map(_process_doc, dataset, contexts))
@@ -16,7 +16,7 @@ def process_docs(
 def postprocess_docs(predictions, references):
     predictions_context = {
         "answer": predictions,
-        "contexts": references["source"],
-        "context_ids": references["source_ids"],
+        "contexts": references["contexts"],
+        "context_ids": references["context_ids"],
     }
     return json.dumps(predictions_context)

--- a/lm_eval/tasks/unitxt/utils.py
+++ b/lm_eval/tasks/unitxt/utils.py
@@ -1,0 +1,22 @@
+import json
+
+import datasets
+
+
+def process_docs(
+    dataset: datasets.Dataset, contexts: tuple[list[str]]
+) -> datasets.Dataset:
+    def _process_doc(doc, ctx):
+        out_doc = {**doc, "source": ctx[0], "source_ids": ctx[1]}
+        return out_doc
+
+    return list(map(_process_doc, dataset, contexts))
+
+
+def postprocess_docs(predictions, references):
+    predictions_context = {
+        "answer": predictions,
+        "contexts": references["source"],
+        "context_ids": references["source_ids"],
+    }
+    return json.dumps(predictions_context)


### PR DESCRIPTION
Run an example with the following configuration:

Custom task.yaml definition:

```yaml
task: my_rag_task
include: unitxt
recipe: card=cards.rag.benchmark.bioasq.en,template=templates.rag.end_to_end.json_predictions # card=cards.rag.benchmark.clap_nq.en,template=templates.rag.end_to_end.json_predictions
rag: 
  session: url=http://localhost:3002/mcp
  request: tool=search,query_field=text,context_field=context,id_field=id
process_docs: !function utils.process_docs
process_results: !function utils.postprocess_docs
```

command: 

```bash
lm_eval --output_path ./output --model hf --model_args pretrained=Qwen/Qwen2-1.5B --tasks my_rag_task --appl
y_chat_template rag --include_path ./my_tasks --log_samples --limit 2
```

TODO 

- [x] Hook in MCP server calls
- [ ] Figure out a better way to handle chat templating portion
- [ ] Document limitations
